### PR TITLE
docs: update Windows advices

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,18 +105,24 @@ In the example, to run John type `my-john`.
 
 ### Acessing OpenCL
 
-To run JtR OpenCL version you must install the snap using `developer mode`. It
+As noted at https://forum.snapcraft.io/t/snaps-and-opencl/8509/17, the use of
+OpenCL by snaps is a problem. Support for NVIDIA cards is under development.
+
+As a "general" solution (or in the case of AMD hardware), the user can run john
+out of the sandbox, unconfined (e.g., run `/snap/john-the-ripper/current/run/john`).
+
+~To run JtR OpenCL version you must install the snap using `developer mode`. It
 enables users to install snaps without enforcing security policies. To do this,
-you must install John using (**UNTESTED**):
+you must install John using (**UNTESTED**):~
 
 ```bash
  sudo snap install john-the-ripper --devmode
 ```
 
-When installed this way, snaps behave similarly to traditional *.deb* packages in
-terms of accessing system resources.
+~When installed this way, snaps behave similarly to traditional *.deb* packages in
+terms of accessing system resources.~
 
-To run JtR OpenCL binary:
+~To run JtR OpenCL binary:~
 
 ```bash
  john-the-ripper.opencl -list=build-info

--- a/readme.md
+++ b/readme.md
@@ -289,10 +289,10 @@ PS C:\john-the-ripper\run> .\john --list=build-info
 Some adjustments may be necessary to allow John the Ripper detect your GPU
 hardware. If you are facing problems, please ask for support.
 
-- That being said, the first advice to be given to anyone facing Windows problems
-would be:
+- That being said, a few advices to anyone facing Windows problems:
   - replacing cygwin's OpenCL library `cygOpenCL-1.dll` in the `run` directory with `OpenCL.dll` installed
-  in the `c:\Windows\System32` folder should make everything _almost_ work. Make a backup of `cygOpenCL-1.dll`, copy in the `OpenCL.dll`, and rename the copied file `cygOpenCL-1.dll`. After this, if you get errors like `Error building kernel /run/kernels/cryptsha512_kernel_GPU.cl` try running john from the subdirectory `kernels` (e.g. from `/run/kernels` run john like `../john.exe`).
+  in the `c:\Windows\System32` folder should make everything _almost_ work. Make a backup of `cygOpenCL-1.dll`, copy in the `OpenCL.dll`, and rename the copied file `cygOpenCL-1.dll`.
+  - if you get errors like `Error building kernel /run/opencl/cryptsha512_kernel_GPU.cl` try running john from the subdirectory `opencl` (e.g. from `JtR\run\opencl` run `..\john.exe`).
 
 Benchmarking:
 


### PR DESCRIPTION
- Separate advice into items. 
- Update OpenCL folder name (it was renamed long ago).