### PR TITLE
maint: run a virus scan on a new Github release

### DIFF
--- a/.github/workflows/virusscan.yml
+++ b/.github/workflows/virusscan.yml
@@ -1,0 +1,18 @@
+name: released
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  virustotal:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: VirusTotal Scan
+        uses: crazy-max/ghaction-virustotal@v3
+        with:
+          vt_api_key: ${{ secrets.VT_API_KEY }}
+          files: |
+            .7z$
+            .zip$


### PR DESCRIPTION
## Describe your changes

Automatically it will run virus scan using VirusTotal.

## Issue ticket number and link

Closes #57 