### PR TITLE
maint: revert some linters changes

### DIFF
--- a/deploy/docker/build.sh
+++ b/deploy/docker/build.sh
@@ -25,6 +25,11 @@
 echo "Release $RELEASE"
 arch=$(uname -m)
 
+# Build options (system wide, disable checks, etc.)
+SYSTEM_WIDE='--with-systemwide'
+X86_REGULAR="--disable-native-tests $SYSTEM_WIDE"
+X86_NO_OPENMP="--disable-native-tests $SYSTEM_WIDE --disable-openmp"
+
 # Install build dependencies
 apt-get update -qq
 export DEBIAN_FRONTEND="noninteractive"
@@ -50,16 +55,16 @@ git clone --depth 10 https://github.com/openwall/john.git
 if [ "$RELEASE" = "true" ] ; then (cd john || true; git checkout "$COMMIT"); fi
 (
     cd john/src || true
-    ./configure --disable-native-tests --with-systemwide --disable-openmp --enable-simd=sse2   && do_build ../run/john-sse2
-    ./configure --disable-native-tests --with-systemwide                  --enable-simd=sse2   && do_build ../run/john-sse2-omp
-    ./configure --disable-native-tests --with-systemwide --disable-openmp --enable-simd=avx    && do_build ../run/john-avx
-    ./configure --disable-native-tests --with-systemwide                  --enable-simd=avx    && do_build ../run/john-avx-omp
-    ./configure --disable-native-tests --with-systemwide --disable-openmp --enable-simd=avx2   && do_build ../run/john-avx2
-    ./configure --disable-native-tests --with-systemwide                  --enable-simd=avx2   && do_build ../run/john-avx2-omp
-    ./configure --disable-native-tests --with-systemwide --disable-openmp --enable-simd=avx512f  && do_build ../run/john-avx512f
-    ./configure --disable-native-tests --with-systemwide                  --enable-simd=avx512f  && do_build ../run/john-avx512f-omp
-    ./configure --disable-native-tests --with-systemwide --disable-openmp --enable-simd=avx512bw && do_build ../run/john-avx512bw
-    ./configure --disable-native-tests --with-systemwide                  --enable-simd=avx512bw && do_build ../run/john-avx512bw-omp
+    do_configure "$X86_NO_OPENMP" --enable-simd=sse2   && do_build ../run/john-sse2
+    do_configure "$X86_REGULAR"   --enable-simd=sse2   && do_build ../run/john-sse2-omp
+    do_configure "$X86_NO_OPENMP" --enable-simd=avx    && do_build ../run/john-avx
+    do_configure "$X86_REGULAR"   --enable-simd=avx    && do_build ../run/john-avx-omp
+    do_configure "$X86_NO_OPENMP" --enable-simd=avx2   && do_build ../run/john-avx2
+    do_configure "$X86_REGULAR"   --enable-simd=avx2   && do_build ../run/john-avx2-omp
+    do_configure "$X86_NO_OPENMP" --enable-simd=avx512f  && do_build ../run/john-avx512f
+    do_configure "$X86_REGULAR"   --enable-simd=avx512f  && do_build ../run/john-avx512f-omp
+    do_configure "$X86_NO_OPENMP" --enable-simd=avx512bw && do_build ../run/john-avx512bw
+    do_configure "$X86_REGULAR"   --enable-simd=avx512bw && do_build ../run/john-avx512bw-omp
 )
 
 # Clean the image

--- a/deploy/flatpak/build.sh
+++ b/deploy/flatpak/build.sh
@@ -56,16 +56,16 @@ if [[ -z "$TASK" ]]; then
 
     if [[ "$arch" == "x86_64" ]]; then
         # x86_64 CPU (OMP and SIMD fallback)
-        ./configure "$X86_NO_OPENMP" --enable-simd=sse2   CPPFLAGS="-D_BOXED" && do_build ../run/john-sse2
-        ./configure "$X86_REGULAR"   --enable-simd=sse2   CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-sse2\\\"\"" && do_build ../run/john-sse2-omp
-        ./configure "$X86_NO_OPENMP" --enable-simd=avx    CPPFLAGS="-D_BOXED" && do_build ../run/john-avx
-        ./configure "$X86_REGULAR"   --enable-simd=avx    CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-sse2-omp\\\"\"" && do_build ../run/john-avx-omp
-        ./configure "$X86_NO_OPENMP" --enable-simd=avx2   CPPFLAGS="-D_BOXED" && do_build ../run/john-avx2
-        ./configure "$X86_REGULAR"   --enable-simd=avx2   CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx2\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx-omp\\\"\"" && do_build ../run/john-avx2-omp
-        ./configure "$X86_NO_OPENMP" --enable-simd=avx512f  CPPFLAGS="-D_BOXED" && do_build ../run/john-avx512f
-        ./configure "$X86_REGULAR"   --enable-simd=avx512f  CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512f\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx2-omp\\\"\"" && do_build ../run/john-avx512f-omp
-        ./configure "$X86_NO_OPENMP" --enable-simd=avx512bw CPPFLAGS="-D_BOXED" && do_build ../run/john-avx512bw
-        ./configure "$X86_REGULAR"   --enable-simd=avx512bw CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512bw\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx512f-omp\\\"\"" && do_build ../run/john-avx512bw-omp
+        do_configure "$X86_NO_OPENMP" --enable-simd=sse2   CPPFLAGS="-D_BOXED" && do_build ../run/john-sse2
+        do_configure "$X86_REGULAR"   --enable-simd=sse2   CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-sse2\\\"\"" && do_build ../run/john-sse2-omp
+        do_configure "$X86_NO_OPENMP" --enable-simd=avx    CPPFLAGS="-D_BOXED" && do_build ../run/john-avx
+        do_configure "$X86_REGULAR"   --enable-simd=avx    CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-sse2-omp\\\"\"" && do_build ../run/john-avx-omp
+        do_configure "$X86_NO_OPENMP" --enable-simd=avx2   CPPFLAGS="-D_BOXED" && do_build ../run/john-avx2
+        do_configure "$X86_REGULAR"   --enable-simd=avx2   CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx2\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx-omp\\\"\"" && do_build ../run/john-avx2-omp
+        do_configure "$X86_NO_OPENMP" --enable-simd=avx512f  CPPFLAGS="-D_BOXED" && do_build ../run/john-avx512f
+        do_configure "$X86_REGULAR"   --enable-simd=avx512f  CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512f\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx2-omp\\\"\"" && do_build ../run/john-avx512f-omp
+        do_configure "$X86_NO_OPENMP" --enable-simd=avx512bw CPPFLAGS="-D_BOXED" && do_build ../run/john-avx512bw
+        do_configure "$X86_REGULAR"   --enable-simd=avx512bw CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512bw\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx512f-omp\\\"\"" && do_build ../run/john-avx512bw-omp
 
         #Create a 'john' executable
         (
@@ -74,8 +74,8 @@ if [[ -z "$TASK" ]]; then
         )
     else
         # Non X86 CPU (OMP fallback)
-        ./configure "$OTHER_NO_OPENMP"   CPPFLAGS="-D_BOXED" && do_build "../run/john-$arch"
-        ./configure "$OTHER_REGULAR"     CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-$arch\\\"\"" && do_build ../run/john-omp
+        do_configure "$OTHER_NO_OPENMP"   CPPFLAGS="-D_BOXED" && do_build "../run/john-$arch"
+        do_configure "$OTHER_REGULAR"     CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-$arch\\\"\"" && do_build ../run/john-omp
 
         #Create a 'john' executable
         (

--- a/deploy/flatpak/com.openwall.John.json
+++ b/deploy/flatpak/com.openwall.John.json
@@ -67,7 +67,8 @@
                 },
                 {
                     "type": "file",
-                    "path": "../tests/run_build.sh"
+                    "path": ".https://raw.githubusercontent.com/openwall/john-packages/main/tests/run_build.sh",
+                    "sha256": "4f90497d81b542ee50a50e1888c797f791967350aed528dff918b4a806783770"
                 },
                 {
                     "type": "file",

--- a/deploy/snap/build.sh
+++ b/deploy/snap/build.sh
@@ -93,16 +93,16 @@ echo "---------------------------- BUILDING -----------------------------"
 
 if [[ "$arch" == "x86_64" ]]; then
     # x86_64 CPU (OMP and SIMD fallback)
-    ./configure "$X86_NO_OPENMP" --enable-simd=sse2   CPPFLAGS="-D_SNAP -D_BOXED" && do_build ../run/john-sse2
-    ./configure "$X86_REGULAR"   --enable-simd=sse2   CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-sse2\\\"\"" && do_build ../run/john-sse2-omp
-    ./configure "$X86_NO_OPENMP" --enable-simd=avx    CPPFLAGS="-D_SNAP -D_BOXED" && do_build ../run/john-avx
-    ./configure "$X86_REGULAR"   --enable-simd=avx    CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-sse2-omp\\\"\"" && do_build ../run/john-avx-omp
-    ./configure "$X86_NO_OPENMP" --enable-simd=avx2   CPPFLAGS="-D_SNAP -D_BOXED" && do_build ../run/john-avx2
-    ./configure "$X86_REGULAR"   --enable-simd=avx2   CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx2\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx-omp\\\"\"" && do_build ../run/john-avx2-omp
-    ./configure "$X86_NO_OPENMP" --enable-simd=avx512f  CPPFLAGS="-D_SNAP -D_BOXED" && do_build ../run/john-avx512f
-    ./configure "$X86_REGULAR"   --enable-simd=avx512f  CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512f\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx2-omp\\\"\"" && do_build ../run/john-avx512f-omp
-    ./configure "$X86_NO_OPENMP" --enable-simd=avx512bw CPPFLAGS="-D_SNAP -D_BOXED" && do_build ../run/john-avx512bw
-    ./configure "$X86_REGULAR"   --enable-simd=avx512bw CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512bw\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx512f-omp\\\"\"" && do_build ../run/john-avx512bw-omp
+    do_configure "$X86_NO_OPENMP" --enable-simd=sse2   CPPFLAGS="-D_SNAP -D_BOXED" && do_build ../run/john-sse2
+    do_configure "$X86_REGULAR"   --enable-simd=sse2   CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-sse2\\\"\"" && do_build ../run/john-sse2-omp
+    do_configure "$X86_NO_OPENMP" --enable-simd=avx    CPPFLAGS="-D_SNAP -D_BOXED" && do_build ../run/john-avx
+    do_configure "$X86_REGULAR"   --enable-simd=avx    CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-sse2-omp\\\"\"" && do_build ../run/john-avx-omp
+    do_configure "$X86_NO_OPENMP" --enable-simd=avx2   CPPFLAGS="-D_SNAP -D_BOXED" && do_build ../run/john-avx2
+    do_configure "$X86_REGULAR"   --enable-simd=avx2   CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx2\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx-omp\\\"\"" && do_build ../run/john-avx2-omp
+    do_configure "$X86_NO_OPENMP" --enable-simd=avx512f  CPPFLAGS="-D_SNAP -D_BOXED" && do_build ../run/john-avx512f
+    do_configure "$X86_REGULAR"   --enable-simd=avx512f  CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512f\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx2-omp\\\"\"" && do_build ../run/john-avx512f-omp
+    do_configure "$X86_NO_OPENMP" --enable-simd=avx512bw CPPFLAGS="-D_SNAP -D_BOXED" && do_build ../run/john-avx512bw
+    do_configure "$X86_REGULAR"   --enable-simd=avx512bw CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512bw\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx512f-omp\\\"\"" && do_build ../run/john-avx512bw-omp
 
     #Create a 'john' executable
     (
@@ -111,8 +111,8 @@ if [[ "$arch" == "x86_64" ]]; then
     )
 else
     # Non X86 CPU (OMP fallback)
-    ./configure "$OTHER_NO_OPENMP"   CPPFLAGS="-D_SNAP -D_BOXED" && do_build "../run/john-$arch"
-    ./configure "$OTHER_REGULAR"     CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-$arch\\\"\"" && do_build ../run/john-omp
+    do_configure "$OTHER_NO_OPENMP"   CPPFLAGS="-D_SNAP -D_BOXED" && do_build "../run/john-$arch"
+    do_configure "$OTHER_REGULAR"     CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-$arch\\\"\"" && do_build ../run/john-omp
 
     #Create a 'john' executable
     (

--- a/tests/run_build.sh
+++ b/tests/run_build.sh
@@ -46,3 +46,9 @@ function do_build () {
     fi
     set +e
 }
+
+function do_configure() {
+  # shellcheck disable=SC2068
+  set -- $@
+  ./configure "$@"
+}


### PR DESCRIPTION
This produces a lot of linter warnings. Anyway, I want to split on spaces, like when building a command line.

I was able to test the Dockerfile and the snap. I still need a solution that mutes linters and do what I need.