### PR TITLE
Add an action capable of tagging Docker images

### DIFF
--- a/.github/workflows/tag-image.yml
+++ b/.github/workflows/tag-image.yml
@@ -1,0 +1,57 @@
+###############################################################################
+#        _       _             _   _            _____  _
+#       | |     | |           | | | |          |  __ \(_)
+#       | | ___ | |__  _ __   | |_| |__   ___  | |__) |_ _ __  _ __   ___ _ __
+#   _   | |/ _ \| '_ \| '_ \  | __| '_ \ / _ \ |  _  /| | '_ \| '_ \ / _ \ '__|
+#  | |__| | (_) | | | | | | | | |_| | | |  __/ | | \ \| | |_) | |_) |  __/ |
+#   \____/ \___/|_| |_|_| |_|  \__|_| |_|\___| |_|  \_\_| .__/| .__/ \___|_|
+#                                                       | |   | |
+#                                                       |_|   |_|
+#
+# Copyright (c) 2023 Claudio André <claudioandre.br at gmail.com>
+#
+# This program comes with ABSOLUTELY NO WARRANTY; express or implied.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, as expressed in version 2, seen at
+# http://www.gnu.org/licenses/gpl-2.0.html
+###############################################################################
+# Github Action to tag an existing John the Ripper's Docker image
+# More info at https://github.com/openwall/john-packages
+
+---
+name: Tag Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "SHA of the image to be tagged"
+        required: true
+        default: "sha256:03cdfefca444c83d31193b94538a0fc9eeeea16130108bfc3bf89312ed7d7159"
+      tag:
+        description: "The tag that will be created"
+        required: true
+        default: "latest"
+
+permissions:
+  contents: read
+
+jobs:
+  add-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
+        with:
+          egress-policy: audit
+
+      - name: Add a tag to Docker Image
+        uses: shrink/actions-docker-registry-tag@v3
+        with:
+          registry: ghcr.io
+          repository: "${{ github.repository }}"
+          target: "${{ github.event.inputs.target }}"
+          tags: "${{ github.event.inputs.tag }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Describe your changes

Allow to tag a Docker image:
* Avoid doing things locally; 
* To have the log of what was tagged, when and by whom in a public repository.

PS: For `workflow_dispatch`, I HAVE to have a version of the file in the main branch, so, I will merge to be able to test.
