### PR TITLE
Add arm64 Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,6 +77,12 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
       - name: Check out the repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -96,7 +102,7 @@ jobs:
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: "${{ github.workspace }}/deploy/docker"
-          platforms: linux/amd64 #,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event.inputs.push }}
           build-args: |
             RELEASE="${{ github.event.inputs.release }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -115,7 +115,7 @@ jobs:
             ${{ env.REPO }}:${{ github.event.inputs.tag }}_J${{ github.run_number }}
 
   provenance:
-    if: ${{ github.event.inputs.push }} == 'true'
+    if: ${{ github.event.inputs.push == 'true' }}
     needs: [build]
     permissions:
       actions: read # for detecting the Github Actions environment.

--- a/deploy/docker/build.sh
+++ b/deploy/docker/build.sh
@@ -108,8 +108,6 @@ cd john/src || exit 1
 
 if [ "$arch" == "x86_64" ]; then
     # x86_64 CPU (OMP and SIMD binaries)
-    do_configure "$X86_NO_OPENMP" --enable-simd=sse2     && do_build ../run/john-sse2
-    do_configure "$X86_REGULAR"   --enable-simd=sse2     && do_build ../run/john-sse2-omp
     do_configure "$X86_NO_OPENMP" --enable-simd=avx      && do_build ../run/john-avx
     do_configure "$X86_REGULAR"   --enable-simd=avx      && do_build ../run/john-avx-omp
     do_configure "$X86_NO_OPENMP" --enable-simd=avx2     && do_build ../run/john-avx2

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -23,12 +23,14 @@
 
 set -e
 echo "$@"
-ids="sse2-omp sse2 avx-omp avx xop-omp xop avx2-omp avx2
+ids="sse2-omp sse2 avx-omp avx avx2-omp avx2
           avx512f-omp avx512f avx512bw-omp avx512bw
           ztex-omp ztex best
+          john-omp john-aarch64
           "
 binaries="/john/run/john-avx512bw-omp /john/run/john-avx512f-omp /john/run/john-avx2-omp
-          /john/run/john-xop-omp /john/run/john-avx-omp /john/run/john-sse2-omp
+          /john/run/john-avx-omp /john/run/john-sse2-omp
+          /john/run/john-omp
           "
 requested="$1"
 
@@ -41,7 +43,7 @@ if [[ "$requested" = 'sse2-omp' || "$requested" = 'sse2' ]]; then
     exec "/john/run/john-$requested" "$@"
 elif [[ "$requested" = 'avx-omp' || "$requested" = 'avx' || "$requested" = 'avx2-omp' || "$requested" = 'avx2' ]]; then
     exec "/john/run/john-$requested" "$@"
-elif [[ "$requested" = 'xop-omp' || "$requested" = 'xop' ]]; then
+elif [[ "$requested" = 'john-omp' || "$requested" = 'john-aarch64' ]]; then
     exec "/john/run/john-$requested" "$@"
 elif [[ "$requested" = 'avx512f-omp'  || "$requested" = 'avx512f'  || "$requested" = 'avx512bw-omp'  || "$requested" = 'avx512bw' ]]; then
     exec "/john/run/john-$requested" "$@"
@@ -61,7 +63,7 @@ else
     if [[ -f /john/run/john-sse2-omp ]]; then
         exec /john/run/john-sse2-omp "$@"
     else
-        exec /john/run/john-avx2-omp "$@"
+        exec /john/run/john-omp "$@"
     fi
 fi
 message='### See you soon! ###'

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -23,13 +23,13 @@
 
 set -e
 echo "$@"
-ids="sse2-omp sse2 avx-omp avx avx2-omp avx2
+ids="avx-omp avx avx2-omp avx2
           avx512f-omp avx512f avx512bw-omp avx512bw
           ztex-omp ztex best
           john-omp john-aarch64
           "
 binaries="/john/run/john-avx512bw-omp /john/run/john-avx512f-omp /john/run/john-avx2-omp
-          /john/run/john-avx-omp /john/run/john-sse2-omp
+          /john/run/john-avx-omp
           /john/run/john-omp
           "
 requested="$1"
@@ -39,9 +39,7 @@ if [[ $# -gt 0 && "$ids" == *"$requested"* ]]; then
     shift
 fi
 
-if [[ "$requested" = 'sse2-omp' || "$requested" = 'sse2' ]]; then
-    exec "/john/run/john-$requested" "$@"
-elif [[ "$requested" = 'avx-omp' || "$requested" = 'avx' || "$requested" = 'avx2-omp' || "$requested" = 'avx2' ]]; then
+if [[ "$requested" = 'avx-omp' || "$requested" = 'avx' || "$requested" = 'avx2-omp' || "$requested" = 'avx2' ]]; then
     exec "/john/run/john-$requested" "$@"
 elif [[ "$requested" = 'john-omp' || "$requested" = 'john-aarch64' ]]; then
     exec "/john/run/john-$requested" "$@"
@@ -60,8 +58,8 @@ elif [[ "$requested" = 'best' ]]; then
     done
     echo 'No suitable john binary found'
 else
-    if [[ -f /john/run/john-sse2-omp ]]; then
-        exec /john/run/john-sse2-omp "$@"
+    if [[ -f /john/run/john-avx-omp ]]; then
+        exec /john/run/john-avx-omp "$@"
     else
         exec /john/run/john-omp "$@"
     fi

--- a/docs/examples-docker.md
+++ b/docs/examples-docker.md
@@ -66,7 +66,7 @@
 
 ## Binaries
 
-The available binaries (their IDs are sse2-omp, sse2, avx-omp, etc) are:
+The available linux/amd64 binaries (their IDs are sse2-omp, sse2, avx-omp, etc) are:
 
 - /john/run/john-sse2-omp (default binary)
 - /john/run/john-sse2
@@ -78,6 +78,11 @@ The available binaries (their IDs are sse2-omp, sse2, avx-omp, etc) are:
 - /john/run/john-avx512f
 - /john/run/john-avx512bw-omp
 - /john/run/john-avx512bw
+
+The available linux/arm64 binaries (their IDs are john-omp and john-aarch64) are:
+
+- /john/run/john-omp (default binary)
+- /john/run/john-aarch64
 
 Binaries available on Docker image John 1.9.0 Jumbo 1 (their IDs are ztex and ztex-no-omp) are:
 

--- a/docs/examples-docker.md
+++ b/docs/examples-docker.md
@@ -58,7 +58,6 @@
 ## Compare the performance of SIMD extensions
 
 ```bash
- docker run ghcr.io/openwall/john:latest sse2     --test=10 --format=SHA512crypt
  docker run ghcr.io/openwall/john:latest avx      --test=10 --format=SHA512crypt
  docker run ghcr.io/openwall/john:latest avx2     --test=10 --format=SHA512crypt
  docker run ghcr.io/openwall/john:latest avx512bw --test=10 --format=SHA512crypt
@@ -66,11 +65,9 @@
 
 ## Binaries
 
-The available linux/amd64 binaries (their IDs are sse2-omp, sse2, avx-omp, etc) are:
+The available linux/amd64 binaries (their IDs are avx-omp, avx, etc) are:
 
-- /john/run/john-sse2-omp (default binary)
-- /john/run/john-sse2
-- /john/run/john-avx-omp
+- /john/run/john-avx-omp (default binary)
 - /john/run/john-avx
 - /john/run/john-avx2-omp
 - /john/run/john-avx2

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -72,11 +72,11 @@ and IBM System z.
 | PowerPC | Altivec |
 | RISC-V 64 | SIMD is not supported |
 | S390x | SIMD is not supported |
-| x86| AVX512BW, AVX512F, AVX2, AVX, SSE2 |
+| x86| AVX512BW, AVX512F, AVX2, AVX |
 
 | Architecture | Supported but not tested |
 | :-: | :-: |
-| x86| XOP, SSE4.2, SSE4.1, SSSE3 |
+| x86| XOP, SSE4.2, SSE4.1, SSSE3, SSE2 |
 
 #### CI Builds and Artifacts
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -276,8 +276,6 @@ if [[ -z "${TEST##*MY_FULL*}" ]]; then
 fi
 
 if [[ -z "${TEST##*SIMD*}" ]]; then
-    /john/run/john-sse2-omp      --test=10 --format=SHA512crypt
-    /john/run/john-sse2          --test=10 --format=SHA512crypt
     /john/run/john-avx-omp       --test=10 --format=SHA512crypt
     /john/run/john-avx           --test=10 --format=SHA512crypt
     /john/run/john-avx2-omp      --test=10 --format=SHA512crypt


### PR DESCRIPTION
## Describe your changes

* Add building Docker images targeting arm64 architecture.
* Stop building Docker SSE2 binaries

Closes #171 and #170
****

Delivered:

```
$ crane manifest ghcr.io/openwall/john
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:c116266c2670c457e21f68e5bf42c060c9a8f355837b49adf6b491fda7d52fef",
      "size": 2008,
      "platform": {
        "architecture": "amd64",                          <======= HERE <=======
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:7214d45e9aa0f6251aeed0ef843f7016252698dc423804a651df866203c0de84",
      "size": 2004,
      "platform": {
        "architecture": "arm64",                          <======= HERE <=======
        "os": "linux"
      }
    },
[...]
```