### PR TITLE
Docker: fix arm64 binary IDs

### DIFF
--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -26,7 +26,7 @@ echo "$@"
 ids="avx-omp avx avx2-omp avx2
           avx512f-omp avx512f avx512bw-omp avx512bw
           ztex-omp ztex best
-          john-omp john-aarch64
+          omp aarch64
           "
 binaries="/john/run/john-avx512bw-omp /john/run/john-avx512f-omp /john/run/john-avx2-omp
           /john/run/john-avx-omp
@@ -41,7 +41,7 @@ fi
 
 if [[ "$requested" = 'avx-omp' || "$requested" = 'avx' || "$requested" = 'avx2-omp' || "$requested" = 'avx2' ]]; then
     exec "/john/run/john-$requested" "$@"
-elif [[ "$requested" = 'john-omp' || "$requested" = 'john-aarch64' ]]; then
+elif [[ "$requested" = 'omp' || "$requested" = 'aarch64' ]]; then
     exec "/john/run/john-$requested" "$@"
 elif [[ "$requested" = 'avx512f-omp'  || "$requested" = 'avx512f'  || "$requested" = 'avx512bw-omp'  || "$requested" = 'avx512bw' ]]; then
     exec "/john/run/john-$requested" "$@"

--- a/docs/examples-docker.md
+++ b/docs/examples-docker.md
@@ -78,7 +78,7 @@ The available linux/amd64 binaries (their IDs are avx-omp, avx, etc) are:
 - /john/run/john-avx512bw-omp
 - /john/run/john-avx512bw
 
-The available linux/arm64 binaries (their IDs are john-omp and john-aarch64) are:
+The available linux/arm64 binaries (their IDs are omp and aarch64) are:
 
 - /john/run/john-omp (default binary)
 - /john/run/john-aarch64


### PR DESCRIPTION
## Describe your changes

The ID should just be the architecture or technology of the binary that will be used.
