### PR TITLE
Remove a duplicate test

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -268,11 +268,6 @@ if [[ -z "${TEST##*MY_FULL*}" ]]; then
     "$JTR_BIN" -test-full=1 --format=sha256crypt-opencl
     "$JTR_BIN" -test-full=1 --format=sha512crypt-opencl
     total=$((total + 5))
-
-    echo "------------------------- test full --------------------------"
-    echo "$ JtR -test-full=1 --format=cpu"
-    "$JTR_BIN" -test-full=1 --format=cpu
-    total=$((total + 1))
 fi
 
 if [[ -z "${TEST##*SIMD*}" ]]; then


### PR DESCRIPTION
## Describe your changes

The removed test was duplicated within an OpenCL verification procedure. It should be executed by its own procedure.
