### PR TITLE
Solaris update vmaction to version 1.0

### DIFF
--- a/deploy/Solaris-Delivery.yml
+++ b/deploy/Solaris-Delivery.yml
@@ -43,7 +43,7 @@ jobs:
       _JUMBO_RELEASE: ${{ github.event.inputs.release }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build on Solaris
         id: test
         uses: vmactions/solaris-vm@v1

--- a/deploy/Solaris-Delivery.yml
+++ b/deploy/Solaris-Delivery.yml
@@ -51,7 +51,6 @@ jobs:
           envs: 'TARGET_ARCH EXTRA BUILD_OPTS TEST BASE'
           usesh: true
           copyback: false
-          mem: 2048
           prepare: |
             pkgutil -y -i socat
             pkgutil -y -i git

--- a/deploy/Solaris-Delivery.yml
+++ b/deploy/Solaris-Delivery.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build on Solaris
         id: test
-        uses: vmactions/solaris-vm@v0
+        uses: vmactions/solaris-vm@v1
         with:
           envs: 'TARGET_ARCH EXTRA BUILD_OPTS TEST BASE'
           usesh: true

--- a/deploy/Solaris-Delivery.yml
+++ b/deploy/Solaris-Delivery.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     name: Solaris 11
     env:
       TARGET_ARCH: "SOLARIS"


### PR DESCRIPTION
## Describe your changes

- Solaris no longer boots in version 0.9.
- Use the default VM memory size.
- Much faster now.