### PR TITLE
flatpak: disable opencl build

### DIFF
--- a/deploy/flatpak/build.sh
+++ b/deploy/flatpak/build.sh
@@ -64,7 +64,7 @@ export TEST
 export JTR_CL
 
 # Build options (system wide, disable checks, etc.)
-SYSTEM_WIDE='--with-systemwide'
+SYSTEM_WIDE='--with-systemwide --disable-opencl'
 X86_REGULAR="--disable-native-tests $SYSTEM_WIDE"
 X86_NO_OPENMP="--disable-native-tests $SYSTEM_WIDE --disable-openmp"
 


### PR DESCRIPTION
## Describe your changes

The SDK has some OpenCL runtime (but I don't know how the runtime behaves).

It doesn't make sense to include OpenCL formats in the flatpak binary (meanwhile).
