### PR TITLE
build(deps): bump vscode/devcontainers/base in /IDE/.devcontainer

### DIFF
--- a/IDE/.devcontainer/Dockerfile
+++ b/IDE/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/master/containers
 
-FROM mcr.microsoft.com/vscode/devcontainers/base:jammy@sha256:58455121a1914fc23fa3440ef505e63776b889b667245c00de3ab3176be07ab7
+FROM mcr.microsoft.com/vscode/devcontainers/base:jammy@sha256:08845a02c0472bb026f9cc4bb74bccaf2039945e7a9b41c4dbcce578c1830d40
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
## Describe your changes

Bot is too lazy, I'm updating it myself.
Bumps vscode/devcontainers/base from `5845512` to `08845a0`.
