### PR TITLE
packages: give the option to use zip when downloading a package

### DIFF
--- a/deploy/Mac_ARM-Delivery.yml
+++ b/deploy/Mac_ARM-Delivery.yml
@@ -60,11 +60,12 @@ macOS_task:
     - source .ci/clean_package.sh
 
     - 7z a -t7z -m0=lzma -mx=9 -mfb=64 -md=128m -ms=on JtR-macArm.7z ./
-    - sha256sum -- JtR-macArm.7z
+    - 7z a -tzip -mx=9 JtR-macArm.zip ./
+    - sha256sum -- JtR-macArm.*
 
   always:
     binaries_artifacts:
-      path: "JtR-macArm.7z"
+      path: "JtR-macArm.*"
 
     id_artifacts:
       path: "Build._ID"

--- a/deploy/Windows-Delivery.yml
+++ b/deploy/Windows-Delivery.yml
@@ -219,6 +219,8 @@ steps:
       REM # Save John the Ripper zip file
       if exist "%JTR_FOLDER%\run\john.exe" 7z a -t7z -m0=lzma -mx=9 -mfb=64 -md=128m -ms=on "win_x%bits%.7z" "%JTR_FOLDER%"
       move "win_x%bits%.7z" c:\
+      if exist "%JTR_FOLDER%\run\john.exe" 7z a -tzip -mx=9 "win_x%bits%.zip" "%JTR_FOLDER%"
+      move "win_x%bits%.zip" c:\
     displayName: "Clean Up the Package"
 
   # Compute checksums ########################################################
@@ -232,7 +234,7 @@ steps:
 
       if ($Zipfile = Get-ChildItem "c:\win_x$env:Bits.7z") {
           # Print files hashes
-          Get-FileHash "c:\win_x$env:Bits.7z"
+          Get-FileHash "c:\win_x$env:Bits.*"
       }
 
       Write-Output "**************************************************************************"


### PR DESCRIPTION
## Describe your changes

So, stop forcing to use using 7z tools. Avoid the risk of using 7zip.
****
I still need to test it. During testing, I might try to find out if tar is acceptable (at least on Mac).