### PR TITLE
build(deps): bump super-linter to upstream (6.4.0)

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 0
 
       - name: Linter
-        uses: github/super-linter@9d8128f17796a16326ceed5a607d5639a47feb82 # v6.4.0
+        uses: super-linter/super-linter@9d8128f17796a16326ceed5a607d5639a47feb82 # v6.4.0
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_CHECKOV: false


### PR DESCRIPTION
## Describe your changes

I got confused and was using a fork repository.
