### PR TITLE
add SLSA level 1 for release assets

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -22,6 +22,7 @@ NVIDIA
 opencl
 openssl
 openwall
+philips
 radeon
 risc
 riscv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@
 #                                                       | |   | |
 #                                                       |_|   |_|
 #
-# Copyright (c) 2021-2023 Claudio André <claudioandre.br at gmail.com>
+# Copyright (c) 2021-2024 Claudio André <dev at claudioandre.slmail.me>
 #
 # This program comes with ABSOLUTELY NO WARRANTY; express or implied.
 #
@@ -17,11 +17,11 @@
 # the Free Software Foundation, as expressed in version 2, seen at
 # http://www.gnu.org/licenses/gpl-2.0.html
 ###############################################################################
-# GitHub Action to scan a release using VirusTotal
+# GitHub Action to scan using VirusTotal and produce a Provenance file
 # More info at https://github.com/openwall/john-packages
 
 ---
-name: Virus Scan
+name: Release Process
 
 "on":
   release:
@@ -58,3 +58,32 @@ jobs:
           files: |
             .7z$
             .zip$
+
+  provenance:
+    name: provenance
+    needs: [virustotal]
+    runs-on: ubuntu-latest
+    permissions:
+      # required to update the release. But it is a security issue.
+      contents: write
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            uploads.github.com:443
+
+      - name: Generate provenance for Release
+        uses: philips-labs/slsa-provenance-action@6b2fd198d38ba72fb3cc08fbc52da2ebaef2efad # v0.9.0
+        with:
+          command: generate
+          subcommand: github-release
+          arguments: --artifact-path release-assets --output-path 'Computed-provenance.json' --tag-name ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Describe your changes

Implement the level 1 requirements of the SLSA framework. Better than nothing.

So, the Docker image is SLSA level 3 and the release will be level 1.

Supply-chain Levels for Software Artifacts, or SLSA ("salsa"): 

* It’s a security framework, a checklist of standards and controls to prevent tampering, improve integrity, and secure packages and infrastructure. It’s how you get from "safe enough" to being as resilient as possible, at any link in the chain.

I.e.:

![image](https://github.com/openwall/john-packages/assets/1702923/a7bf8bc7-f584-4601-b813-35d35d742352)

File:
![image](https://github.com/openwall/john-packages/assets/1702923/69066011-2ae8-4377-b5f8-cb1bf62347ca)

## Issue ticket number and link

#322