### PR TITLE
Generate signed provenance of new releases

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -66,6 +66,7 @@ Dockerfiles
 drwx
 drwxr
 drwxrwxr
+dsaltares
 dynamicbase
 editorconfig
 elfutils

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,8 +49,7 @@ name: Docker
 env:
   REPO: ghcr.io/${{ github.repository_owner }}/john
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   build:
@@ -58,8 +57,9 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      attestations: write
+      id-token: write
       packages: write
-      contents: read
 
     outputs:
       image: ${{ env.REPO }}:${{ github.event.inputs.tag }}
@@ -76,12 +76,15 @@ jobs:
             archive.ubuntu.com:80
             auth.docker.io:443
             developer.download.nvidia.com:443
+            fulcio.sigstore.dev:443
             ghcr.io:443
             github.com:443
+            objects.githubusercontent.com:443
             ports.ubuntu.com:80
             production.cloudflare.docker.com:443
             raw.githubusercontent.com:443
             registry-1.docker.io:443
+            rekor.sigstore.dev:443
             security.ubuntu.com:80
 
       - name: Check out the repo
@@ -150,6 +153,13 @@ jobs:
             annotation-index.org.opencontainers.image.vendor=Openwall,\
             annotation-index.org.opencontainers.image.version=${{ steps.data.outputs.version }}"
 
+      - name: Upload attestation
+        uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4 # v1.1.1
+        if: ${{ github.event.inputs.push == 'true' }}
+        with:
+          subject-name: ${{ env.REPO }}:${{ github.event.inputs.tag }}
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
+
   provenance:
     if: ${{ github.event.inputs.push == 'true' }}
     needs: [build]
@@ -157,6 +167,7 @@ jobs:
       actions: read # for detecting the GitHub Actions environment.
       id-token: write # for creating OIDC tokens for signing.
       packages: write # for uploading attestations.
+
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
     with:
       image: ${{ needs.build.outputs.image }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,8 @@ jobs:
     needs: [virustotal]
     runs-on: ubuntu-latest
     permissions:
-      # required to update the release. But it is a security issue.
-      contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Harden Runner
@@ -75,15 +75,22 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            fulcio.sigstore.dev:443
             github.com:443
             objects.githubusercontent.com:443
+            rekor.sigstore.dev:443
             uploads.github.com:443
 
-      - name: Generate provenance for Release
-        uses: philips-labs/slsa-provenance-action@6b2fd198d38ba72fb3cc08fbc52da2ebaef2efad # v0.9.0
+      - name: Get assets
+        uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # v1.1.2
         with:
-          command: generate
-          subcommand: github-release
-          arguments: --artifact-path release-assets --output-path 'Computed-provenance.json' --tag-name ${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          version: tags/${{ github.ref_name }}
+          regex: true
+          file: ".*zip$|.*7z$|Created-on.*.txt$"
+          target: local-app/
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest release
+        uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4 # v1.1.1
+        with:
+          subject-path: "${{ github.workspace }}//local-app"


### PR DESCRIPTION
## Describe your changes

It doesn't make much sense to continue using the strategy of creating a JSON file. Use the GitHub infrastructure makes more sense.

Now GitHub has a “special” link to show attestations:
- https://github.com/openwall/john-packages/attestations.

I'll merge #373 to keep useful information about the matter, but the new yaml file (attest.yml) will be deleted soon (after changing the Docker image creation process).

## Issue ticket number and link

#322 
****

* Tested on a forked repository, downloading release assets worked correctly.
* No alphabetical order (bad).

![image](https://github.com/openwall/john-packages/assets/1702923/2006a007-db10-47bf-a881-fdc4df5672ab)
