### PR TITLE
Disable more formats while fuzzing

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -31,7 +31,6 @@ if [[ "$SANITIZER" == "address" ]]; then
 	# Asan
 	./configure --enable-asan
 	make -sj4
-
 	cp ../run/john "$OUT"/
 
 	echo "------------------ Disable problematic formats -------------------"
@@ -47,7 +46,14 @@ if [[ "$SANITIZER" == "undefined" ]]; then
 	# Ubsan
 	./configure --enable-ubsan
 	make -sj4
+	cp ../run/john "$OUT"/
 
+	echo "------------------ Disable problematic formats -------------------"
+	{
+		echo '[Local:Disabled:Formats]'
+		echo 'RACF-KDFAES = Y'
+		echo 'ZIP = Y'
+	} >>../run/john-local.conf
 	echo "------------------------- UBSAN fuzzing --------------------------"
 	echo "$ JtR UBSAN --test=0"
 	../run/john --test=0

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -105,6 +105,7 @@ intrinsics
 jscpd
 JTR
 jtrcrackers
+KDFAES
 keepass
 Keplr
 keygen


### PR DESCRIPTION
## Describe your changes

It's difficult to reproduce the fuzzLite failure elsewhere. At the very least we are documenting the formats that fail.

```
Testing: RACF-KDFAES [KDFAES (DES + HMAC-SHA256/64 + AES-256)]...
racf_kdfaes_fmt_plug.c:372:23: runtime error: left shift of 238 by 24 places cannot be represented in type 'int'
```

```
Testing: ZIP, WinZip [PBKDF2-SHA1 256/256 AVX2 8x2]...
zip_fmt_plug.c:144:27: runtime error: index 64 out of bounds for type 'unsigned char[60]'
```
