### PR TITLE
Docker: use `latest` tag for latest stable image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,10 +36,10 @@ name: Docker
         description: "The image tag"
         required: true
         type: choice
-        default: "latest"
+        default: "bleeding"
         options:
+          - bleeding
           - latest
-          - rolling
       extra:
         description: "Add another image tag"
         type: string

--- a/docs/examples-docker.md
+++ b/docs/examples-docker.md
@@ -16,7 +16,7 @@ Using the `--rm` flag to clean up the container and remove the file system after
 
 ```bash
  docker run --rm ghcr.io/openwall/john # => uses the best SIMD available, tag 'latest' can be omitted
- docker run --rm ghcr.io/openwall/john:rolling # => uses the latest rolling release
+ docker run --rm ghcr.io/openwall/john:bleeding # => uses the latest bleeding release
  docker run --rm ghcr.io/openwall/john:latest best # => uses the best SIMD available
  docker run --rm ghcr.io/openwall/john:latest avx2 --list=build-info
  docker run --rm ghcr.io/openwall/john:latest avx2-omp --list=build-info

--- a/readme.md
+++ b/readme.md
@@ -495,7 +495,7 @@ Run John the Ripper and check if it is working:
 
 ```bash
  docker run ghcr.io/openwall/john # => uses the best SIMD available, tag 'latest' can be omitted
- docker run ghcr.io/openwall/john:rolling # => uses the latest rolling release
+ docker run ghcr.io/openwall/john:bleeding # => uses the latest bleeding release
  docker run ghcr.io/openwall/john:latest best # => uses the best SIMD available
 ```
 
@@ -508,9 +508,9 @@ The highlights (👀):
 - has auto-selection of the best SIMD if user specifies `best` as the `<binary id>`;
   - example: `docker run ghcr.io/openwall/john:latest best -list=build-info`.
 - the released version of John 1.9.0 Jumbo 1+ (is a rolling release):
-  - install from the command-line: `docker pull ghcr.io/openwall/john:rolling`.
-- the development version:
   - install from the command-line: `docker pull ghcr.io/openwall/john:latest`.
+- the development version:
+  - install from the command-line: `docker pull ghcr.io/openwall/john:bleeding`.
 
 ### Docker Image Deployments
 


### PR DESCRIPTION
## Describe your changes

Docker's `latest` tag will mean the latest stable version released (in our case, a rolling release) of a Docker Image.

## Issue ticket number and link

Close #385.
