### PR TITLE
Reactivate ASAN for crypt format

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -34,9 +34,9 @@ if [[ "$SANITIZER" == "address" ]]; then
 	cp ../run/john "$OUT"/
 
 	echo "------------------ Disable problematic formats -------------------"
-	echo '[Local:Disabled:Formats]' >>../run/john-local.conf
-	echo 'crypt = Y' >>../run/john-local.conf
-
+	{
+		echo '[Local:Disabled:Formats]'
+	} >>../run/john-local.conf
 	echo "-------------------------- ASAN fuzzing --------------------------"
 	echo "$ JtR ASAN --test=0"
 	../run/john --test=0


### PR DESCRIPTION
## Describe your changes

It appears that the recent fixes applied upstream have fixed the issue we were experiencing. We are comparing 100% failure in the past with 3 successful runs today [1].

To be sure, I need to find an old run (an old version of the Docker image) that failed and run it again using the latest upstream bleeding code.

[1] This is already a strong indication that something has been improved/fixed.

## Issue ticket number and link

Fix https://github.com/openwall/john/issues/5411
See https://github.com/openwall/john/issues/5491 (rare event; perhaps related?)