### PR TITLE
maint: stop building AVX512F binaries

### DIFF
--- a/CI/readme.md
+++ b/CI/readme.md
@@ -66,18 +66,18 @@ using:
 
 #### Supported SIMD Extensions
 
-| Architecture |         Tested SIMD          |
-| :----------: | :--------------------------: |
-|    ARM v8    |            ASIMD             |
-|   PowerPC    |           Altivec            |
-|  RISC-V 64   |    SIMD is not supported     |
-|    S390x     |    SIMD is not supported     |
-|     x86      | AVX512BW, AVX512F, AVX2, AVX |
+| Architecture |      Tested SIMD      |
+| :----------: | :-------------------: |
+|    ARM v8    |         ASIMD         |
+|   PowerPC    |        Altivec        |
+|  RISC-V 64   | SIMD is not supported |
+|    S390x     | SIMD is not supported |
+|     x86      |  AVX512BW, AVX2, AVX  |
 
-| Architecture |     Supported but not tested     |
-| :----------: | :------------------------------: |
-|    ARM v7    |               NEON               |
-|     x86      | XOP, SSE4.2, SSE4.1, SSSE3, SSE2 |
+| Architecture |         Supported but not tested          |
+| :----------: | :---------------------------------------: |
+|    ARM v7    |                   NEON                    |
+|     x86      | AVX512F, XOP, SSE4.2, SSE4.1, SSSE3, SSE2 |
 
 #### CI Builds and Artifacts
 

--- a/deploy/Windows-Delivery.yml
+++ b/deploy/Windows-Delivery.yml
@@ -96,10 +96,8 @@ steps:
       shell "./configure $EXE_NO_OMP --enable-simd=avx2                                                                                                                                                  && make -s clean && make -sj2 2>&1 && make -s strip && mv ../run/john ../run/john-avx2"
       shell "./configure $EXE_NORMAL --enable-simd=avx2  CPPFLAGS='-DOMP_FALLBACK_BINARY=\`"\\\`"john-avx2\\\`"\`"  -DCPU_FALLBACK_BINARY=\`"\\\`"john-avx-omp\\\`"\`" '   && make -s clean && make -sj2 2>&1 && make -s strip && mv ../run/john ../run/john-avx2-omp"
 
-      shell "./configure $EXE_NO_OMP --enable-simd=avx512f  CPPFLAGS='-fno-asynchronous-unwind-tables '                                                                                                                                          && make -s clean && make -sj2 2>&1 && make -s strip && mv ../run/john ../run/john-avx512f"
-      shell "./configure $EXE_NORMAL --enable-simd=avx512f  CPPFLAGS='-fno-asynchronous-unwind-tables -DOMP_FALLBACK_BINARY=\`"\\\`"john-avx512f\\\`"\`"  -DCPU_FALLBACK_BINARY=\`"\\\`"john-avx2-omp\\\`"\`" '    && make -s clean && make -sj2 2>&1 && make -s strip && mv ../run/john ../run/john-avx512f-omp"
       shell "./configure $EXE_NO_OMP --enable-simd=avx512bw CPPFLAGS='-fno-asynchronous-unwind-tables '                                                                                                                                          && make -s clean && make -sj2 2>&1 && make -s strip && mv ../run/john ../run/john-avx512bw"
-      shell "./configure $EXE_NORMAL --enable-simd=avx512bw CPPFLAGS='-fno-asynchronous-unwind-tables -DOMP_FALLBACK_BINARY=\`"\\\`"john-avx512bw\\\`"\`" -DCPU_FALLBACK_BINARY=\`"\\\`"john-avx512f-omp\\\`"\`" ' && make -s clean && make -sj2 2>&1 && make -s strip && mv ../run/john ../run/john-avx512bw-omp"
+      shell "./configure $EXE_NORMAL --enable-simd=avx512bw CPPFLAGS='-fno-asynchronous-unwind-tables -DOMP_FALLBACK_BINARY=\`"\\\`"john-avx512bw\\\`"\`" -DCPU_FALLBACK_BINARY=\`"\\\`"john-avx2-omp\\\`"\`" ' && make -s clean && make -sj2 2>&1 && make -s strip && mv ../run/john ../run/john-avx512bw-omp"
       $EXE_NAME = "john-avx512bw-omp.exe"
 
       # Configure OpenCL ICD

--- a/deploy/docker/build.sh
+++ b/deploy/docker/build.sh
@@ -89,8 +89,6 @@ if [ "$arch" == "x86_64" ]; then
 	do_configure "$X86_REGULAR" --enable-simd=avx && do_build ../run/john-avx-omp
 	do_configure "$X86_NO_OPENMP" --enable-simd=avx2 && do_build ../run/john-avx2
 	do_configure "$X86_REGULAR" --enable-simd=avx2 && do_build ../run/john-avx2-omp
-	do_configure "$X86_NO_OPENMP" --enable-simd=avx512f && do_build ../run/john-avx512f
-	do_configure "$X86_REGULAR" --enable-simd=avx512f && do_build ../run/john-avx512f-omp
 	do_configure "$X86_NO_OPENMP" --enable-simd=avx512bw && do_build ../run/john-avx512bw
 	do_configure "$X86_REGULAR" --enable-simd=avx512bw && do_build ../run/john-avx512bw-omp
 else

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -24,11 +24,11 @@
 set -e
 echo "$@"
 ids="avx-omp avx avx2-omp avx2
-          avx512f-omp avx512f avx512bw-omp avx512bw
+          avx512bw-omp avx512bw
           ztex-omp ztex best
           omp aarch64
           "
-binaries="/john/run/john-avx512bw-omp /john/run/john-avx512f-omp /john/run/john-avx2-omp
+binaries="/john/run/john-avx512bw-omp /john/run/john-avx2-omp
           /john/run/john-avx-omp
           /john/run/john-omp
           "
@@ -43,7 +43,7 @@ if [[ "$requested" = 'avx-omp' || "$requested" = 'avx' || "$requested" = 'avx2-o
 	exec "/john/run/john-$requested" "$@"
 elif [[ "$requested" = 'omp' || "$requested" = 'aarch64' ]]; then
 	exec "/john/run/john-$requested" "$@"
-elif [[ "$requested" = 'avx512f-omp' || "$requested" = 'avx512f' || "$requested" = 'avx512bw-omp' || "$requested" = 'avx512bw' ]]; then
+elif [[ "$requested" = 'avx512bw-omp' || "$requested" = 'avx512bw' ]]; then
 	exec "/john/run/john-$requested" "$@"
 elif [[ "$requested" = 'ztex-omp' || "$requested" = 'ztex' ]]; then
 	echo "Binary /john/run/john-$requested  disabled (please, open a bug report)"

--- a/deploy/flatpak/build.sh
+++ b/deploy/flatpak/build.sh
@@ -52,10 +52,8 @@ if [[ "$arch" == "x86_64" ]]; then
 	do_configure "$X86_REGULAR" --enable-simd=avx CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx\\\"\" " && do_build ../run/john-avx-omp
 	do_configure "$X86_NO_OPENMP" --enable-simd=avx2 CPPFLAGS="-D_BOXED" && do_build ../run/john-avx2
 	do_configure "$X86_REGULAR" --enable-simd=avx2 CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx2\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx-omp\\\"\"" && do_build ../run/john-avx2-omp
-	do_configure "$X86_NO_OPENMP" --enable-simd=avx512f CPPFLAGS="-D_BOXED" && do_build ../run/john-avx512f
-	do_configure "$X86_REGULAR" --enable-simd=avx512f CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512f\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx2-omp\\\"\"" && do_build ../run/john-avx512f-omp
 	do_configure "$X86_NO_OPENMP" --enable-simd=avx512bw CPPFLAGS="-D_BOXED" && do_build ../run/john-avx512bw
-	do_configure "$X86_REGULAR" --enable-simd=avx512bw CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512bw\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx512f-omp\\\"\"" && do_build ../run/john-avx512bw-omp
+	do_configure "$X86_REGULAR" --enable-simd=avx512bw CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512bw\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx2-omp\\\"\"" && do_build ../run/john-avx512bw-omp
 	BINARY="john-avx512bw-omp"
 else
 	# Non X86 CPU (OMP fallback)

--- a/deploy/metadata/com.openwall.John.metainfo.xml
+++ b/deploy/metadata/com.openwall.John.metainfo.xml
@@ -82,7 +82,7 @@
         <p>All binaries support SIMD:</p>
         <ul>
           <li>The aarch64 binaries support ASIMD</li>
-          <li>The X86_64 binaries support AVX, AVX2, AVX512F and AVX512BW</li>
+          <li>The X86_64 binaries support AVX, AVX2, and AVX512BW</li>
         </ul>
       </description>
     </release>

--- a/deploy/snap/build.sh
+++ b/deploy/snap/build.sh
@@ -76,10 +76,8 @@ if [[ "$arch" == "x86_64" ]]; then
 	do_configure "$X86_REGULAR" --enable-simd=avx CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx\\\"\"" && do_build ../run/john-avx-omp
 	do_configure "$X86_NO_OPENMP" --enable-simd=avx2 CPPFLAGS="-D_SNAP -D_BOXED" && do_build ../run/john-avx2
 	do_configure "$X86_REGULAR" --enable-simd=avx2 CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx2\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx-omp\\\"\"" && do_build ../run/john-avx2-omp
-	do_configure "$X86_NO_OPENMP" --enable-simd=avx512f CPPFLAGS="-D_SNAP -D_BOXED" && do_build ../run/john-avx512f
-	do_configure "$X86_REGULAR" --enable-simd=avx512f CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512f\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx2-omp\\\"\"" && do_build ../run/john-avx512f-omp
 	do_configure "$X86_NO_OPENMP" --enable-simd=avx512bw CPPFLAGS="-D_SNAP -D_BOXED" && do_build ../run/john-avx512bw
-	do_configure "$X86_REGULAR" --enable-simd=avx512bw CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512bw\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx512f-omp\\\"\"" && do_build ../run/john-avx512bw-omp
+	do_configure "$X86_REGULAR" --enable-simd=avx512bw CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512bw\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx2-omp\\\"\"" && do_build ../run/john-avx512bw-omp
 	BINARY="john-avx512bw-omp"
 	OPENCL_SUPPORT="Yes"
 else

--- a/docs/examples-docker.md
+++ b/docs/examples-docker.md
@@ -73,8 +73,6 @@ The available linux/amd64 binaries (their IDs are avx-omp, avx, etc) are:
 - /john/run/john-avx
 - /john/run/john-avx2-omp
 - /john/run/john-avx2
-- /john/run/john-avx512f-omp
-- /john/run/john-avx512f
 - /john/run/john-avx512bw-omp
 - /john/run/john-avx512bw
 

--- a/requirements.hash
+++ b/requirements.hash
@@ -2,7 +2,7 @@
 a1788258b118178c77e6d7de16723e07b2aa9191e7414a84e756fa831d02d0aa  ./clean_package.sh
 b6dd937dfccbc23fd618c5b259698c1eafd5ef54e7965c778c3ae1599c12a113  ./helper.sh
 a11e89f1d10be4235e247bc815e0549f06bef22fb5414acecf7d3e82cee0a70a  ./package_version.sh
-508aa12b1fa9bce92ef494c4d8a24cd68f6ee8d7c008c05c2d5e55a9d788b046  ./run_tests.sh
+376ed40297353794e2c9e43c277e19743f37965ba9c4eb8260e8dff3230c1be9  ./run_tests.sh
 5e4629cce7b4552876dc308a659e878b1b196df60327df50f462ec899d6d28ed  ./show_info.sh
 11aa0fb376310c49eb5c915f5db2c066d2e8b35950e8a6b604d75104994ec04f  ./Handle-self-confined-system-wide-build.patch
 1f93d80dd97a5450c6e36759148d2767e29bbf987c078d5e5089b702e77aece5  ./Remove-peflags-from-the-default-target.patch

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -287,8 +287,6 @@ if [[ -z "${TEST##*SIMD*}" ]]; then
 	/john/run/john-avx --test=10 --format=SHA512crypt
 	/john/run/john-avx2-omp --test=10 --format=SHA512crypt
 	/john/run/john-avx2 --test=10 --format=SHA512crypt
-	/john/run/john-avx512f-omp --test=10 --format=SHA512crypt
-	/john/run/john-avx512f --test=10 --format=SHA512crypt
 	/john/run/john-avx512bw-omp --test=10 --format=SHA512crypt
 	/john/run/john-avx512bw --test=10 --format=SHA512crypt
 


### PR DESCRIPTION
## Describe your changes

Drop the obsolete and exotic AVX512F. Current Intel CPUs either have AVX512BW or don't have any AVX-512. For future Intel CPUs, the separation isn't going to be across the F vs. BW.

Spare hardware and build time.

## Issue ticket number and link

#444.