### PR TITLE
Docker: update base distro to Ubuntu 24.04 LTS

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -120,9 +120,13 @@ jobs:
         with:
           images: ${{ env.REPO }}:${{ github.event.inputs.tag }}
           labels: |
-            org.opencontainers.image.authors="Claudio André <claudioandre.br at gmail com>"
-            software="John the Ripper ${{ github.event.inputs.VERSION_NAME }}"
-            org.opencontainers.image.description="John the Ripper is an Open Source password security auditing and password recovery tool. See https://www.openwall.com/john/"
+            software=John the Ripper ${{ github.event.inputs.VERSION_NAME }}
+            org.opencontainers.image.authors=Claudio André <claudioandre.br at gmail com>
+            org.opencontainers.image.description=John the Ripper is an Open Source password security auditing and password recovery tool. See https://www.openwall.com/john/
+            org.opencontainers.image.title=John the Ripper CE Auditing Tool
+            org.opencontainers.image.url=https://www.openwall.com/john
+            org.opencontainers.image.version=${{ steps.data.outputs.version }}
+            org.opencontainers.image.vendor=Openwall
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@5927c834f5b4fdf503fca6f4c7eccda82949e1ee # v3.1.0
@@ -153,17 +157,7 @@ jobs:
           labels: |
             ${{ steps.meta.outputs.labels }}
           outputs: "type=image,name=target,\
-            annotation-index.software=John the Ripper ${{ github.event.inputs.VERSION_NAME }},\
-            annotation-index.org.opencontainers.image.authors=Claudio André <claudioandre.br at gmail com>,\
-            annotation-index.org.opencontainers.image.created=${{ steps.data.outputs.now }},\
-            annotation-index.org.opencontainers.image.description=John the Ripper is an Open Source password security auditing and password recovery tool. See https://www.openwall.com/john/,\
-            annotation-index.org.opencontainers.image.licenses=GPL-2.0,\
-            annotation-index.org.opencontainers.image.revision=${{ steps.data.outputs.revision }},\
-            annotation-index.org.opencontainers.image.source=https://github.com/openwall/john-packages.git,\
-            annotation-index.org.opencontainers.image.title=John the Ripper CE Auditing Tool,\
-            annotation-index.org.opencontainers.image.url=https://www.openwall.com/john,\
-            annotation-index.org.opencontainers.image.vendor=Openwall,\
-            annotation-index.org.opencontainers.image.version=${{ steps.data.outputs.version }}"
+            annotation-index.org.opencontainers.image.description=John the Ripper is an Open Source password security auditing and password recovery tool. See https://www.openwall.com/john/"
 
       - name: Upload attestation
         uses: actions/attest-build-provenance@5e9cb68e95676991667494a6a4e59b8a2f13e1d0 # v1.3.3

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -23,7 +23,7 @@
 # John the Ripper Docker image is hosted at GitHub Packages
 #   https://github.com/openwall/john-packages/pkgs/container/john
 
-FROM nvidia/cuda:12.5.1-base-ubuntu22.04@sha256:47181750209e68cab2e36c3e0e8ab0ab8d76bdabbb418e56e4b0ac7b08b97d34 AS build
+FROM nvidia/cuda:12.5.1-base-ubuntu24.04@sha256:3c873cb78e31c983287909538738aca572887a919dae789bd04219e1d702c294 AS build
 WORKDIR /build/
 COPY build.sh .
 
@@ -36,7 +36,7 @@ RUN ./build.sh "$TYPE" "$RELEASE_COMMIT"
 # ==================================================================
 # Build the final lean Docker image
 # ------------------------------------------------------------------
-FROM nvidia/cuda:12.5.1-base-ubuntu22.04@sha256:47181750209e68cab2e36c3e0e8ab0ab8d76bdabbb418e56e4b0ac7b08b97d34
+FROM nvidia/cuda:12.5.1-base-ubuntu24.04@sha256:3c873cb78e31c983287909538738aca572887a919dae789bd04219e1d702c294
 
 # ==================================================================
 # Runtime setup and libraries
@@ -50,9 +50,9 @@ RUN useradd -U -m JtR \
     && export DEBIAN_FRONTEND="noninteractive" \
     && apt-get update -qq \
     && apt-get install -y --no-install-recommends \
-        libssl3=3.0* \
-        libgomp1=12.3* \
-        ocl-icd-libopencl1=2.2* \
+        libssl3t64=3.0* \
+        libgomp1=14* \
+        ocl-icd-libopencl1=2.3* \
 # ==================================================================
 # Clean up the image (shrink the Docker image)
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Describe your changes

Update the Docker base to Ubuntu 24 LTS. Also, a no-op change.

Already tested.