### PR TITLE
IDE environment adjustments

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -57,6 +57,7 @@ cyggomp
 cygz
 davidanson
 debhelper
+deluser
 devcontainer
 distro
 dmg

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+
+  - package-ecosystem: devcontainers
+    directory: /
+    schedule:
+      interval: "weekly"
+      day: "saturday"

--- a/IDE/.devcontainer/Dockerfile
+++ b/IDE/.devcontainer/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | bash -s -- -y
+RUN deluser --remove-home ubuntu
 
 USER vscode
 HEALTHCHECK NONE

--- a/IDE/.devcontainer/Dockerfile
+++ b/IDE/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM mcr.microsoft.com/vscode/devcontainers/base:noble@sha256:4584130239525059f7afd0014db436c4e9775872e4db0ec903c6e628480b9f6e
 
-ENV NODE_DOWNLOAD_SHA256="f8fb478685fb916cc70858200595a4f087304bcde1e69aa713bf2eb41695afc1"
+ENV NODE_DOWNLOAD_SHA256="74908c4272d48941f93aa66e7f366be632b76a77fbdcb8899a63821af6e85bb9"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/IDE/.devcontainer/devcontainer.json
+++ b/IDE/.devcontainer/devcontainer.json
@@ -1,6 +1,5 @@
 {
   "name": "Ubuntu",
-  "remoteUser": "vscode",
   "mounts": [
     "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
   ],

--- a/IDE/.devcontainer/devcontainer.json
+++ b/IDE/.devcontainer/devcontainer.json
@@ -1,26 +1,35 @@
 {
-	"name": "Ubuntu",
-	"remoteUser": "vscode",
-	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],
-	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
-
-	"build": {
-		"dockerfile": "Dockerfile",
-		"args": { "VARIANT": "noble" }
-	},
-
-	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
-	},
-
-	"extensions": [
-		"davidanson.vscode-markdownlint",
-		"esbenp.prettier-vscode",
-		"galarius.vscode-opencl",
-		"jeff-hykin.better-cpp-syntax",
-		"ms-vscode.cpptools-extension-pack",
-		"ms-vscode.cpptools-themes",
-		"ms-vscode.cpptools",
-		"sonarsource.sonarlint-vscode"
-	]
+  "name": "Ubuntu",
+  "remoteUser": "vscode",
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
+  ],
+  "runArgs": [
+    "--cap-add=SYS_PTRACE",
+    "--security-opt",
+    "seccomp=unconfined"
+  ],
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "VARIANT": "noble"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      },
+      "extensions": [
+        "davidanson.vscode-markdownlint",
+        "esbenp.prettier-vscode",
+        "galarius.vscode-opencl",
+        "jeff-hykin.better-cpp-syntax",
+        "ms-vscode.cpptools-extension-pack",
+        "ms-vscode.cpptools-themes",
+        "ms-vscode.cpptools",
+        "sonarsource.sonarlint-vscode"
+      ]
+    }
+  }
 }

--- a/IDE/.devcontainer/devcontainer.json
+++ b/IDE/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 
 	"build": {
 		"dockerfile": "Dockerfile",
-		"args": { "VARIANT": "jammy" }
+		"args": { "VARIANT": "noble" }
 	},
 
 	"settings": {


### PR DESCRIPTION
## Describe your changes

Minor changes:

- fix node installer hash;
- formatting adjustments and a typo;
- at the end a simple change caused by something really odd [1][2];

[1] `VS Code` plus `Docker` created some processes in my environment using a user **that does not exist in my environment** (the user exists only within the Docker container).
```
1001      124506  0.0  0.0   2800  1664 ?        Ss   18:01   0:00 /bin/sh
1001      124680  0.0  0.0   2800  1664 ?        Ss   18:01   0:00 /bin/sh
1001      124722  0.0  0.4 1025352 42900 ?       Sl   18:01   0:00 /home/vscode/.vscode-server/bin/f1e16e1e6214d7c44d078b1f0607b2388f29d729/node /tmp/vscode-remote-containers-server-9aa039bc-eccf-48cf-b817-aa98d880798c.js
1001      124807  0.0  0.0   2800  1792 ?        Ss   18:01   0:00 sh /home/vscode/.vscode-server/bin/f1e16e1e6214d7c44d078b1f0607b2388f29d729/bin/code-server --log debug --force-disable-user-env --server-data-dir /home/vscode/.vscode-server --use-host-proxy --telemetry-level all --accept-server-license-terms --host 127.0.0.1 --port 0 --connection-token-file /home/vscode/.vscode-server/data/Machine/.connection-token-f1e16e1e6214d7c44d078b1f0607b2388f29d729 --extensions-download-dir /home/vscode/.vscode-server/extensionsCache --install-extension davidanson.vscode-markdownlint --install-extension esbenp.prettier-vscode --install-extension galarius.vscode-opencl --install-extension jeff-hykin.better-cpp-syntax --install-extension ms-vscode.cpptools-extension-pack --install-extension ms-vscode.cpptools-themes --install-extension ms-vscode.cpptools --install-extension sonarsource.sonarlint-vscode --start-server --disable-websocket-compression --skip-requirements-check
```
[2] This text is still not clear, but the problem itself is that it is really weird:
> The base Docker image generated and made available by Microsoft [a] already has an ubuntu user (UID=1000) and a vscode user (UID=1001) registered. No problem occurs if we directly run a container based on this image, even selecting vscode as user, but for some reason, when someone uses the VS Code feature (Docker container as a development environment [b]), 'vscode-server' creates a container based on the image [a] but it defines the user who runs the container on the host as UID=1001 (a non-existent user on my host)

> This results in access denied issues on any file edited using VS Code. Therefore, we need to at least create a workaround, forcing the vscode user to be UID=1000.

[a] mcr.microsoft.com/vscode/devcontainers/base:noble
[b] The Dev Containers extension lets you use a Docker container as
    a full-featured development environment.