### PR TITLE
Update egress policy in release.yml

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -24,6 +24,7 @@ awor
 aws
 basekit
 bestpractices
+bigfiles
 bugtracker
 BUILDID
 buildlog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            bigfiles.virustotal.com:443
             objects.githubusercontent.com:443
             www.virustotal.com:443
 


### PR DESCRIPTION
## Describe your changes

Since I am seeing access errors in “VirusTotal Scan” job, update the network policy in release.yml as recommended by the audit log. Using the recommended policy.