### PR TITLE
Fix Trivy GH action permissions (#563)

### DIFF
--- a/.github/workflows/trivy-rootfs.yml
+++ b/.github/workflows/trivy-rootfs.yml
@@ -34,6 +34,10 @@ jobs:
   trivy-code-security-scan:
     name: Scan rootfs
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/.github/workflows/trivy-scanfs.yml
+++ b/.github/workflows/trivy-scanfs.yml
@@ -37,7 +37,11 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            api.github.com:443
+            ghcr.io:443
             github.com:443
+            objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Describe your changes

I forgot to set these permissions in the original PR. Unfortunately, access to aquasecurity's Docker image is very problematic and returns many TOOMANYREQUESTS errors.
