### PR TITLE
Add Trivy misconfig scan

### DIFF
--- a/.github/workflows/trivy-SBOM.yml
+++ b/.github/workflows/trivy-SBOM.yml
@@ -59,7 +59,8 @@ jobs:
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # 0.28.0
         with:
           scan-type: "fs"
-          scanners: vuln,secret,license
+          scanners: vuln,secret,misconfig,license
+          skip-files: cloud-tool/security-group.tf # See #577
           format: "github"
           output: "dependency-results.sbom.json"
           image-ref: "."

--- a/.github/workflows/trivy-scanfs.yml
+++ b/.github/workflows/trivy-scanfs.yml
@@ -56,9 +56,9 @@ jobs:
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # 0.28.0
         with:
           scan-type: "fs"
-          scanners: vuln,secret,license # misconfig
+          scanners: vuln,secret,misconfig,license
+          skip-files: cloud-tool/security-group.tf # See #577
           exit-code: 1
-          ignore-unfixed: true
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
           TRIVY_USERNAME: ${{ github.actor }}

--- a/cloud-tool/ec2.tf
+++ b/cloud-tool/ec2.tf
@@ -48,6 +48,10 @@ resource "aws_instance" "worker" {
     cpu_credits = "standard"
   }
 
+  root_block_device {
+    encrypted = true
+  }
+
   metadata_options {
     http_tokens                 = "required"
     http_put_response_hop_limit = 2


### PR DESCRIPTION
## Describe your changes

The security group rules have been set to wide open by default. In reality, I can't restrict them without knowing the environment the end user wants to use.

That said, we are ignoring the failure:
- Security group rule allows egress to multiple public internet addresses.
    
```
    cloud-tool/security-group.tf (terraform)
    ========================================
    Tests: 4 (SUCCESSES: 0, FAILURES: 4, EXCEPTIONS: 0)
    Failures: 4 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 4)
```