### PR TITLE
Properly disable dependency review in forks

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   dependency-review:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.repository == 'openwall/john-packages' }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## Describe your changes

Correction to ensure that the “Dependency Review” job is only run in the project's original repository.

Fix: 9fe355a555cd70a4538a3a1d9fda80b5351591b2.

There is some debugging in the commit to be removed next.