### PR TITLE
Pin the hash of rust installer

### DIFF
--- a/IDE/.devcontainer/Dockerfile
+++ b/IDE/.devcontainer/Dockerfile
@@ -25,13 +25,14 @@
 FROM mcr.microsoft.com/vscode/devcontainers/base:noble@sha256:436147909915f53a19b33104ac9d3055ae54782f7e236920852c2c4443d516ac
 
 ENV NODE_DOWNLOAD_SHA256="dd3bc508520fcdfdc8c4360902eac90cba411a7e59189a80fb61fcbea8f4199c"
+ENV RUST_DOWNLOAD_SHA256="32a680a84cf76014915b3f8aa44e3e40731f3af92cd45eb0fcc6264fd257c428"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
-        build-essential=* cpio=* gdb=* golang=* libbz2-dev=* libgmp-dev=* libpcap-dev=* \
-        libpocl-dev=* libssl-dev=* ocl-icd-opencl-dev=* pkg-config=* pocl-opencl-icd=* \
-        pre-commit=* shellcheck=* yasm=* zlib1g-dev=* \
+        build-essential=* ca-certificates=* cpio=* gdb=* golang=* libbz2-dev=* libgmp-dev=* \
+        libpcap-dev=* libpocl-dev=* libssl-dev=* ocl-icd-opencl-dev=* pkg-config=* \
+        pocl-opencl-icd=* pre-commit=* shellcheck=* yasm=* zlib1g-dev=* \
     #
     && TMPFILE=$(mktemp /tmp/node-XXXXX) \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | \
@@ -43,7 +44,10 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | bash -s -- -y
+RUN TMPFILE=$(mktemp /tmp/node-XXXXX) \
+    && curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | \
+        tee "$TMPFILE" | bash -s -- -y \
+    && echo "$RUST_DOWNLOAD_SHA256  $TMPFILE" | sha256sum -c -
 
 USER vscode
 HEALTHCHECK NONE


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

This commit will resolve and silence the security alert “downloadThenRun not pinned by hash”.

This is a strategy to avoid the risk of possible compromised dependencies.
### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]: https://github.com/openwall/john-packages/blob/main/docs/commit-messages.md#how-a-commit-message-should-be
