### PR TITLE
Add a missing user to fuzzing Docker image

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -27,6 +27,8 @@ RUN git clone --depth 1 https://github.com/openwall/john.git /upstream \
     && apt-get install -y --no-install-recommends \
         libbz2-dev=* libgmp-dev=* libpcap-dev=* \
         libssl-dev=* zlib1g-dev=* \
+    # libFuzzingEngine requires a root user
+    && useradd --uid 0 --non-unique --gid 0 -m tester \
 # ==================================================================
 # Clean up the image (shrink the Docker image)
 # ------------------------------------------------------------------


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

The user that is used by the fuzzing Docker image needs to be properly created in the operating system.

A root user is required.

Fix: b0aae463f7dae99659fe98fcda96550f688a0267.

### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]: https://github.com/openwall/john-packages/blob/main/docs/commit-messages.md#how-a-commit-message-should-be
