### PR TITLE
Disable dependency review in forks

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -38,10 +38,10 @@ permissions:
 
 jobs:
   dependency-review:
-    if: ${{ github.repository == 'openwall/john-packages' }}
     runs-on: ubuntu-latest
     name: dependency-review
 
+    if: github.repository == 'openwall/john-packages'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

Correction to ensure that the “Dependency Review” job is only run in the project's original repository.

Fix: 8cb9fc22f6582413bf053552ce651b636a3c5814.
Fix: 9fe355a555cd70a4538a3a1d9fda80b5351591b2.
### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]: https://github.com/openwall/john-packages/blob/main/docs/commit-messages.md#how-a-commit-message-should-be
