### PR TITLE
fix(ci): use SSH on the merge bot (#607)

### DIFF
--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -100,3 +100,6 @@ index [0-9a-z]{7,40}\.\.[0-9a-z]{7,40}
 # hit-count: 1 file-count: 1
 # curl arguments
 \b(?:\\n|)curl(?:\s+-[a-zA-Z]{1,2}\b)*(?:\s+-[a-zA-Z]{3,})(?:\s+-[a-zA-Z]+)*
+
+# SSH information
+SHA256:ok.{42}username@users.noreply.github.com

--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -49,6 +49,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            github.com:22
             github.com:443
             raw.githubusercontent.com:443
 
@@ -57,10 +58,15 @@ jobs:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
         run: echo "$GITHUB_CONTEXT"
 
+      - uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           ref: main
+          ssh-key: "SHA256:ok+PGEmHdM/emA1zW4KJFOi59cOhuxk9wB3rrUwi1dg username@users.noreply.github.com"
 
       - name: Auto-merge PRs
         run: |


### PR DESCRIPTION
I'm seeing an access denied for the bot (but not for workflow_dispatch). Let's use an SSH user and see what happens.

<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

Add your text here.

### Issue ticket number and link

Add your text here.

### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]: https://github.com/openwall/john-packages/blob/main/docs/commit-messages.md#how-a-commit-message-should-be
