### PR TITLE
Add new labels as exempted

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -58,8 +58,8 @@ jobs:
         with:
           days-before-issue-stale: 14
           days-before-issue-close: 7
-          exempt-issue-labels: "keep open"
-          stale-issue-label: "stale"
+          exempt-issue-labels: "keep open,O: backlog"
+          stale-issue-label: "O: stale"
           stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
           close-issue-message: >
             "This issue was closed because it has been inactive for 7 days since being marked as stale."


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

I've changed the labels of the issues exempt from being marked as stale.

As the bots work every day, I need to merge this today.

### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]: https://github.com/openwall/john-packages/blob/main/docs/commit-messages.md#how-a-commit-message-should-be
