### PR TITLE
Remove the 'run' step in clusterFuzzLite

### DIFF
--- a/.github/workflows/cflite_fuzz.yml
+++ b/.github/workflows/cflite_fuzz.yml
@@ -68,15 +68,3 @@ jobs:
           dry-run: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sanitizer: ${{ matrix.sanitizer }}
-
-      - name: Run Fuzzers (${{ matrix.sanitizer }})
-        id: run
-        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
-        with:
-          language: c
-          dry-run: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          fuzz-seconds: 600
-          mode: "code-change"
-          sanitizer: ${{ matrix.sanitizer }}
-          output-sarif: true


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

As upstream doesn't properly support libFuzzer, we use the fuzzing environment with the fuzzing tools available in 'john' itself. And in this case, the 'run' step is not necessary.

### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]: https://github.com/openwall/john-packages/blob/main/docs/commit-messages.md#how-a-commit-message-should-be
