### PR TITLE
Ignore status of PRs when at forks

### DIFF
--- a/scripts/merge_procedures.sh
+++ b/scripts/merge_procedures.sh
@@ -63,6 +63,11 @@ git config --global user.name "Continuous Integration"
 git config --global user.email "username@users.noreply.github.com"
 DEST_BRANCH="$BRANCH"
 
+if [[ "$OWNER" != "openwall" || "$GITHUB_EVENT_NAME" == "pull_request_review" ]]; then
+	echo "On forks or reviews, I can't see the status of a PR, so ignore it."
+	STATUS=1
+fi
+
 if [[ ("$APPROVALS" -ge 1 && "$STATUS" -ge 1) || "$SKIP" == 'true' ]]; then
 	if [[ "$OWNER" != "openwall" ]]; then
 		echo "The PR comes from a fork."


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

Merge-it is a tool intended for use by human beings.

When it runs on forks, it acts differently.
Well, we have rules that protect the main branch, and a human will request the merge. So, it is safe.

### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]: https://github.com/openwall/john-packages/blob/main/docs/commit-messages.md#how-a-commit-message-should-be
