### PR TITLE
Avoid checking out on forks

### DIFF
--- a/.github/workflows/merge-it.yml
+++ b/.github/workflows/merge-it.yml
@@ -63,17 +63,13 @@ jobs:
             api.github.com:443
             github.com:443
 
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
       - name: Get PR info
         id: context
         run: |
-          gh pr checkout "$PR_URL"
-
-          BRANCH="$(gh pr view --json headRefName        --jq '.headRefName')"
-          OWNER="$(gh pr view --json headRepositoryOwner --jq '.headRepositoryOwner.login')"
-          REPO="$(gh pr view --json headRepository       --jq '.headRepository.name')"
+          URL_ID="https://github.com/openwall/john-packages/pull/$PR_URL"
+          BRANCH="$(gh pr view "$URL_ID" --json headRefName        --jq '.headRefName')"
+          OWNER="$(gh pr view "$URL_ID" --json headRepositoryOwner --jq '.headRepositoryOwner.login')"
+          REPO="$(gh pr view "$URL_ID" --json headRepository       --jq '.headRepository.name')"
 
           if [[ ${{ github.event.inputs.trial }}  == "true" ]]; then
             REQUEST="bot: MERGE trial"


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

In the case of PRs from forks, it might be a bad idea to run a check out. Remove that.

From docs:
- GitHub Actions have imposed restrictions on workflow runs triggered by public repository forks.
- Checking out a branch from a different repository from where the workflow is executing will make that repository the target.

In short, a 'checkout' can confuse the GitHub API.

### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]: https://github.com/openwall/john-packages/blob/main/docs/commit-messages.md#how-a-commit-message-should-be
