### PR TITLE
Allow app to update workflow

### DIFF
--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -39,6 +39,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      workflows: write
 
     name: merge-bot-run
     if: >-

--- a/.github/workflows/merge-it.yml
+++ b/.github/workflows/merge-it.yml
@@ -43,6 +43,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      workflows: write
 
     name: merge-it-run
     uses: openwall/john-packages/.github/workflows/merge-pr.yml@main

--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -57,6 +57,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      workflows: write
 
     if: github.actor == 'claudioandre-br' || github.actor == 'solardiz'
     steps:


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

Allow the bot to update workflow files (this is necessary because we will use it for dependabot updates, which impact workflows a lot).

Human intervention is required to start the bot.

Maybe that's why I was seeing strange errors. GitHub has (just now) added an error message that didn't exist before.

Error message :
- refusing to allow a GitHub App to create or update workflow `.github/workflows/approve-it.yml` without `workflows` permission.
### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [ ] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]: https://github.com/openwall/john-packages/blob/main/docs/commit-messages.md#how-a-commit-message-should-be
