### PR TITLE
Remove fake AWS secret key

### DIFF
--- a/cloud-tool/readme.md
+++ b/cloud-tool/readme.md
@@ -34,14 +34,6 @@ Hint: create an alias for the command.
 
 Create your [AWS profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
 
-Example `~/.aws/credentials`
-
-```text
-[usr]
-aws_access_key_id=AKIAIOSFODNN7EXAMPLE
-aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-```
-
 ### Adjust it to your use case
 
 You need to open and edit the file `variables.tf`.


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

Linters insist on complaining about this, even though it's an example key taken from the AWS documentation.

In any case, the user needs to read AWS documentation (link remains) and select a way of defining their credentials. Defining the `.aws/credentials `file isn't even the only way.

### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]: https://github.com/openwall/john-packages/blob/main/docs/commit-messages.md#how-a-commit-message-should-be
