### PR TITLE
Stop validating Dependabot commits

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  helpUrl: 'https://www.conventionalcommits.org/',
+  // See https://github.com/dependabot/dependabot-core/issues/2445
+  ignores: [(msg) => /Signed-off-by: dependabot\[bot]/m.test(msg)],
 
   rules: {
     'body-case': [2, 'always', 'sentence-case'],


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

We cannot validate Dependabot commits at this time.

### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]:
  https://github.com/openwall/john-packages/blob/main/docs/commit-message.md#how-a-commit-message-should-be
