### PR TITLE
Add context to workflow run in Trivy

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,6 +30,9 @@ jobs:
       # contents: read
       # actions: read
 
+    if:
+      github.repository == 'openwall/john-packages' && github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'schedule')
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -55,21 +58,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: |
-          echo ${{ github.repository }}
-          echo ${{ github.ref }}
-          echo ${{ github.event_name }}
-          echo "--------------------------------------------------"
-          echo "$GITHUB_CONTEXT"
-
       - name: "Run analysis"
         uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
-        if:
-          github.repository == 'openwall/john-packages' && github.ref == 'refs/heads/main' &&
-          (github.event_name == 'push' || github.event_name == 'schedule')
         with:
           results_file: results.sarif
           results_format: sarif
@@ -92,9 +82,6 @@ jobs:
       # format to the repository Actions tab.
       - name: "Upload artifact"
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        if:
-          github.repository == 'openwall/john-packages' && github.ref == 'refs/heads/main' &&
-          (github.event_name == 'push' || github.event_name == 'schedule')
         with:
           name: SARIF file
           path: results.sarif
@@ -103,8 +90,5 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
         uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3.27.5
-        if:
-          github.repository == 'openwall/john-packages' && github.ref == 'refs/heads/main' &&
-          (github.event_name == 'push' || github.event_name == 'schedule')
         with:
           sarif_file: results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -38,9 +38,6 @@ jobs:
       contents: write
       security-events: write
 
-    if:
-      github.repository == 'openwall/john-packages' && github.ref == 'refs/heads/main' &&
-      (github.event_name == 'push')
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -59,8 +56,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: |
+          echo ${{ github.repository }}
+          echo ${{ github.ref }}
+          echo ${{ github.event_name }}
+          echo "--------------------------------------------------"
+          echo "$GITHUB_CONTEXT"
+
       - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
         uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # 0.29.0
+        if:
+          github.repository == 'openwall/john-packages' && github.ref == 'refs/heads/main' &&
+          (github.event_name == 'push' || github.event_name == 'schedule')
         with:
           scan-type: "fs"
           format: "github"
@@ -74,6 +84,9 @@ jobs:
 
       - name: Run Trivy vulnerability scanner with rootfs command
         uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # 0.29.0
+        if:
+          github.repository == 'openwall/john-packages' && github.ref == 'refs/heads/main' &&
+          (github.event_name == 'push' || github.event_name == 'schedule')
         with:
           skip-setup-trivy: true
           scan-type: "rootfs"
@@ -88,5 +101,8 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3.27.5
+        if:
+          github.repository == 'openwall/john-packages' && github.ref == 'refs/heads/main' &&
+          (github.event_name == 'push' || github.event_name == 'schedule')
         with:
           sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

I need information about the workflow execution context in order to identify any points for improvement.

Its behaviour still doesn't make sense. See https://github.com/openwall/john-packages/pull/655#issuecomment-2495506743

### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]:
  https://github.com/openwall/john-packages/blob/main/docs/commit-message.md#how-a-commit-message-should-be
