### PR TITLE
Fail if formatting is recommended

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -62,6 +62,18 @@ jobs:
           ENABLE_COMMITLINT_STRICT_MODE: true
           ENFORCE_COMMITLINT_CONFIGURATION_CHECK: true
           FILTER_REGEX_EXCLUDE: "^/github/workspace/snapcraft.yaml$" # Workaround for Prettier itself
+          FIX_JAVASCRIPT_PRETTIER: true
+          FIX_JSON_PRETTIER: true
+          FIX_MARKDOWN_PRETTIER: true
+          FIX_YAML_PRETTIER: true
           VALIDATE_GIT_MERGE_CONFLICT_MARKERS: false # See https://github.com/super-linter/super-linter/pull/6374
           DEFAULT_BRANCH: "main"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check
+        run: |
+          echo "You should format source code properly!"
+          echo "**********************************************************************"
+          git diff
+          echo "**********************************************************************"
+          git diff --quiet


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

Ask Linter to reformat the source code and fail if Linter suggests changes. This means that the code should have been formatted differently for the PR.

Something like this has already happened to me: the Linter failed because of a single/double quotation mark when a double/single was expected, then, I didn't receive any information and I didn't find out what happened.

### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]:
  https://github.com/openwall/john-packages/blob/main/docs/commit-message.md#how-a-commit-message-should-be
