### PR TITLE
Avoid detached mode in validate.yml

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Branch updated
         run: |
@@ -108,7 +109,7 @@ jobs:
       - name: If '(#999)' matches PR number
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
-          COMMITS="$(git log --oneline origin/main.."${{ github.event.pull_request.head.sha }}" --)"
+          COMMITS="$(git log --oneline origin/main..)"
           echo "HEAD: ${{ github.event.pull_request.head.sha }}"
           echo "$COMMITS" | while read -r COMMIT ; do
               MESSAGE_PR_NUMBER=$(echo "$COMMIT" | grep -oE "\(#[0-9]{3,4}\)$" | cut -d'#' -f 2 | cut -d')' -f 1)


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

In a pull request trigger GitHub Actions checks out in detached HEAD mode, meaning it doesn’t check out your branch by default.

### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]:
  https://github.com/openwall/john-packages/blob/main/docs/commit-message.md#how-a-commit-message-should-be
