### PR TITLE
Revert: ci: enable AES-NI using yasm

### DIFF
--- a/deploy/Windows-Delivery.yml
+++ b/deploy/Windows-Delivery.yml
@@ -45,7 +45,7 @@ steps:
           Write-Host "             =====  Installing Cygwin  =====            " -ForegroundColor White
           Write-Host "--------------------------------------------------------"
           choco install -y cygwin cyg-get
-          cyg-get libssl-devel libbz2-devel libgmp-devel zlib-devel gcc-core libOpenCL-devel libcrypt-devel make wget rebase perl yasm
+          cyg-get libssl-devel libbz2-devel libgmp-devel zlib-devel gcc-core libOpenCL-devel libcrypt-devel make wget rebase perl
       }
 
       # Powershell shell "Bash" run ##########################################

--- a/deploy/snap/snapcraft.yaml
+++ b/deploy/snap/snapcraft.yaml
@@ -118,7 +118,6 @@ parts:
       - wget
       - curl
       - patch
-      - yasm
       # OpenCL stuff is available only in X86 architecture
       - on amd64:
           - libpocl-dev

--- a/requirements.hash
+++ b/requirements.hash
@@ -1,4 +1,4 @@
-25cf08bd196cbe4a432aa92da47f7c5f23523d3bc5c7dd179bd6c1eed454bdc5  ./ci_controller.sh
+8eaf3bbf120f883f688e100b9329ce9629a78f2c775239d7483efd937240f942  ./ci_controller.sh
 e25fca925ee687bc46f5be6487c48ee977b697d05df97ccaca86d36ee8d213dc  ./clean_package.sh
 829470da958b5afce3b2023d66eeac9b41d493e9ad8c20fca25109e156312cf0  ./helper.sh
 75de2f0f7c4c02dd16baab447492de281e90e8413f276f86d6a5faeec9dc9025  ./merge_procedures.sh

--- a/scripts/ci_controller.sh
+++ b/scripts/ci_controller.sh
@@ -40,7 +40,7 @@ if [[ "$EXTRA" == "SIMD" ]]; then
 fi
 
 if [[ $TARGET_ARCH == *"SOLARIS"* && $2 == "BUILD" ]]; then
-	pkg install --accept gcc yasm
+	pkg install --accept gcc
 fi
 
 if [[ "$TARGET_ARCH" == *"macOS"* && $2 == "INFO" ]]; then


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

This reverts commit b6f02548c1228e0284fc6a6f64f97f32da6994db.

Upstream now supports AES-NI (Intel) and AES-CE (ARM, including Apple Silicon) and does not depend on yasm as it's written in C with intrinsics.

So I'm reverting #657.

### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]:
  https://github.com/openwall/john-packages/blob/main/docs/commit-message.md#how-a-commit-message-should-be
