### PR TITLE
Allow Docker image to run 2john tools

### DIFF
--- a/deploy/docker/build.sh
+++ b/deploy/docker/build.sh
@@ -91,10 +91,12 @@ if [ "$arch" == "x86_64" ]; then
 	do_configure "$X86_REGULAR" --enable-simd=avx2 && do_build ../run/john-avx2-omp
 	do_configure "$X86_NO_OPENMP" --enable-simd=avx512bw && do_build ../run/john-avx512bw
 	do_configure "$X86_REGULAR" --enable-simd=avx512bw && do_build ../run/john-avx512bw-omp
+	BINARY="john-avx-omp"
 else
 	# Non X86 CPU (OMP fallback)
 	do_configure "$OTHER_NO_OPENMP" && do_build "../run/john-$arch"
 	do_configure "$OTHER_REGULAR" && do_build ../run/john-omp
+	BINARY="john-omp"
 fi
-do_release "Yes" "Yes" # --system-wide, --support-opencl, --binary-name
+do_release "Yes" "Yes" "$BINARY" # --system-wide, --support-opencl, --binary-name
 do_clean_package


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

As it stands now, there is no john binary for the 2john tools to run.

### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]:
  https://github.com/openwall/john-packages/blob/main/docs/commit-message.md#how-a-commit-message-should-be
