### PR TITLE
Add code to check if a format cracks itself

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -184,6 +184,7 @@ nxcompat
 OBJS
 ocl
 oidc
+oldoffice
 omp
 oneapi
 oneline

--- a/requirements.hash
+++ b/requirements.hash
@@ -3,7 +3,7 @@ e25fca925ee687bc46f5be6487c48ee977b697d05df97ccaca86d36ee8d213dc  ./clean_packag
 829470da958b5afce3b2023d66eeac9b41d493e9ad8c20fca25109e156312cf0  ./helper.sh
 75de2f0f7c4c02dd16baab447492de281e90e8413f276f86d6a5faeec9dc9025  ./merge_procedures.sh
 9e0f8478bb6568b6defc647080637b2944d68e8372655031750849aa77686812  ./package_version.sh
-ad0a8ec80ac460df49a2643a5ea75c98ebe55e6039515ff3b8fc581c974ba698  ./run_tests.sh
+920e962f87bb50a4d8220dc9cde49c6cc58c30f915b4fd54b4f797d5372cc7eb  ./run_tests.sh
 94b462117f4a77f14703c5774a8477dcf6644bfee75bec158c0407e69ba58c73  ./show_info.sh
 9adb8d143854bf59b5dc61fc404513984e6c894f5448a1b31e54d43ca4e80b6b  ./Handle-self-confined-system-wide-build.patch
 3712c35cba3ada6a6df90e19bcfe70f2ed5fb0c62dabe0f4442ca52522ddbf2e  ./Remove-peflags-from-the-default-target.patch


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

Add a test that checks whether the formats are capable of cracking the hashes used in the format definition.

### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]:
  https://github.com/openwall/john-packages/blob/main/docs/commit-message.md#how-a-commit-message-should-be
