### PR TITLE
Remove formats from issues

### DIFF
--- a/CI/disabled/readme.md
+++ b/CI/disabled/readme.md
@@ -86,7 +86,6 @@ Platform #0 name: Intel(R) OpenCL, version: OpenCL 3.0 LINUX\
 'bitlocker-opencl'        #SLOW
 
 # Let's say these are fragile
-'krb5pa-md5-opencl'
 'o5logon-opencl'
 'mscash-opencl'
 'salted_sha-opencl'


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

Remove OpenCL krb5pa-md5 from the list of problematic formats. It has PROBABLY been fixed.

Side effect of openwall/john#5710.

### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]:
  https://github.com/openwall/john-packages/blob/main/docs/commit-message.md#how-a-commit-message-should-be
