### PR TITLE
Update how we build AVX512* binaries

### DIFF
--- a/deploy/Windows-Delivery.yml
+++ b/deploy/Windows-Delivery.yml
@@ -96,8 +96,8 @@ steps:
       shell "./configure $EXE_NO_OMP --enable-simd=avx2                                                                                                                                                  && make -s clean && make -sj2 2>&1 && make -s strip && mv ../run/john ../run/john-avx2"
       shell "./configure $EXE_NORMAL --enable-simd=avx2  CPPFLAGS='-DOMP_FALLBACK_BINARY=\`"\\\`"john-avx2\\\`"\`"  -DCPU_FALLBACK_BINARY=\`"\\\`"john-avx-omp\\\`"\`" '   && make -s clean && make -sj2 2>&1 && make -s strip && mv ../run/john ../run/john-avx2-omp"
 
-      shell "./configure $EXE_NO_OMP --enable-simd=avx512bw CPPFLAGS='-fno-asynchronous-unwind-tables '                                                                                                                                          && make -s clean && make -sj2 2>&1 && make -s strip && mv ../run/john ../run/john-avx512bw"
-      shell "./configure $EXE_NORMAL --enable-simd=avx512bw CPPFLAGS='-fno-asynchronous-unwind-tables -DOMP_FALLBACK_BINARY=\`"\\\`"john-avx512bw\\\`"\`" -DCPU_FALLBACK_BINARY=\`"\\\`"john-avx2-omp\\\`"\`" ' && make -s clean && make -sj2 2>&1 && make -s strip && mv ../run/john ../run/john-avx512bw-omp"
+      shell "./configure $EXE_NO_OMP --enable-simd=avx512 CPPFLAGS='-fno-asynchronous-unwind-tables '                                                                                                                                          && make -s clean && make -sj2 2>&1 && make -s strip && mv ../run/john ../run/john-avx512bw"
+      shell "./configure $EXE_NORMAL --enable-simd=avx512 CPPFLAGS='-fno-asynchronous-unwind-tables -DOMP_FALLBACK_BINARY=\`"\\\`"john-avx512bw\\\`"\`" -DCPU_FALLBACK_BINARY=\`"\\\`"john-avx2-omp\\\`"\`" ' && make -s clean && make -sj2 2>&1 && make -s strip && mv ../run/john ../run/john-avx512bw-omp"
       $EXE_NAME = "john-avx512bw-omp.exe"
 
       # Configure OpenCL ICD

--- a/deploy/docker/build.sh
+++ b/deploy/docker/build.sh
@@ -89,8 +89,8 @@ if [ "$arch" == "x86_64" ]; then
 	do_configure "$X86_REGULAR" --enable-simd=avx && do_build ../run/john-avx-omp
 	do_configure "$X86_NO_OPENMP" --enable-simd=avx2 && do_build ../run/john-avx2
 	do_configure "$X86_REGULAR" --enable-simd=avx2 && do_build ../run/john-avx2-omp
-	do_configure "$X86_NO_OPENMP" --enable-simd=avx512bw && do_build ../run/john-avx512bw
-	do_configure "$X86_REGULAR" --enable-simd=avx512bw && do_build ../run/john-avx512bw-omp
+	do_configure "$X86_NO_OPENMP" --enable-simd=avx512 && do_build ../run/john-avx512bw
+	do_configure "$X86_REGULAR" --enable-simd=avx512 && do_build ../run/john-avx512bw-omp
 	BINARY="john-avx-omp"
 else
 	# Non X86 CPU (OMP fallback)

--- a/deploy/flatpak/build.sh
+++ b/deploy/flatpak/build.sh
@@ -52,8 +52,8 @@ if [[ "$arch" == "x86_64" ]]; then
 	do_configure "$X86_REGULAR" --enable-simd=avx CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx\\\"\" " && do_build ../run/john-avx-omp
 	do_configure "$X86_NO_OPENMP" --enable-simd=avx2 CPPFLAGS="-D_BOXED" && do_build ../run/john-avx2
 	do_configure "$X86_REGULAR" --enable-simd=avx2 CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx2\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx-omp\\\"\"" && do_build ../run/john-avx2-omp
-	do_configure "$X86_NO_OPENMP" --enable-simd=avx512bw CPPFLAGS="-D_BOXED" && do_build ../run/john-avx512bw
-	do_configure "$X86_REGULAR" --enable-simd=avx512bw CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512bw\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx2-omp\\\"\"" && do_build ../run/john-avx512bw-omp
+	do_configure "$X86_NO_OPENMP" --enable-simd=avx512 CPPFLAGS="-D_BOXED" && do_build ../run/john-avx512bw
+	do_configure "$X86_REGULAR" --enable-simd=avx512 CPPFLAGS="-D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512bw\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx2-omp\\\"\"" && do_build ../run/john-avx512bw-omp
 	BINARY="john-avx512bw-omp"
 else
 	# Non X86 CPU (OMP fallback)

--- a/deploy/snap/build.sh
+++ b/deploy/snap/build.sh
@@ -76,8 +76,8 @@ if [[ "$arch" == "x86_64" ]]; then
 	do_configure "$X86_REGULAR" --enable-simd=avx CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx\\\"\"" && do_build ../run/john-avx-omp
 	do_configure "$X86_NO_OPENMP" --enable-simd=avx2 CPPFLAGS="-D_SNAP -D_BOXED" && do_build ../run/john-avx2
 	do_configure "$X86_REGULAR" --enable-simd=avx2 CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx2\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx-omp\\\"\"" && do_build ../run/john-avx2-omp
-	do_configure "$X86_NO_OPENMP" --enable-simd=avx512bw CPPFLAGS="-D_SNAP -D_BOXED" && do_build ../run/john-avx512bw
-	do_configure "$X86_REGULAR" --enable-simd=avx512bw CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512bw\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx2-omp\\\"\"" && do_build ../run/john-avx512bw-omp
+	do_configure "$X86_NO_OPENMP" --enable-simd=avx512 CPPFLAGS="-D_SNAP -D_BOXED" && do_build ../run/john-avx512bw
+	do_configure "$X86_REGULAR" --enable-simd=avx512 CPPFLAGS="-D_SNAP -D_BOXED -DOMP_FALLBACK_BINARY=\"\\\"john-avx512bw\\\"\" -DCPU_FALLBACK_BINARY=\"\\\"john-avx2-omp\\\"\"" && do_build ../run/john-avx512bw-omp
 	BINARY="john-avx512bw-omp"
 	OPENCL_SUPPORT="Yes"
 else


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Describe your changes
<!-- prettier-ignore-end -->

The way we should call `./configure` has changed (in fact, will change/can change).

See https://github.com/openwall/john/pull/5694#issuecomment-2756313493 (so the change is invasive).

### Checklist before requesting a review

- [x] I checked that all workflows return a success.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I followed the [Conventional Commit spec][commitMessage].

### Maintainer tasks

- [x] Label as either: `bug`, `ci`, `docker`, `documentation`, `enhancement`.
- [x] Sign unsigned commits.

[commitMessage]:
  https://github.com/openwall/john-packages/blob/main/docs/commit-message.md#how-a-commit-message-should-be
